### PR TITLE
Remove empty MIP tables

### DIFF
--- a/Tables/CMIP6_CORDEX_day.json
+++ b/Tables/CMIP6_CORDEX_day.json
@@ -1,1 +1,0 @@
-no Variable found for CORDEX_day

--- a/Tables/CMIP6_aerannual.json
+++ b/Tables/CMIP6_aerannual.json
@@ -1,1 +1,0 @@
-no Variable found for aerannual

--- a/Tables/CMIP6_aero.json
+++ b/Tables/CMIP6_aero.json
@@ -1,1 +1,0 @@
-no Variable found for aero

--- a/Tables/CMIP6_cfsites.json
+++ b/Tables/CMIP6_cfsites.json
@@ -1,1 +1,0 @@
-no Variable found for cfsites


### PR DESCRIPTION
This pull request removes empty MIP tables that aren't listed in the [CMIP6 Data Request](http://clipc-services.ceda.ac.uk/dreq/index/miptable.html).
