### PR TITLE
Generic levels missing in some tables

### DIFF
--- a/Tables/CMIP6_AERmon.json
+++ b/Tables/CMIP6_AERmon.json
@@ -9,7 +9,7 @@
         "missing_value": "1e20", 
         "product": "output", 
         "approx_interval": "", 
-        "generic_levels": "", 
+        "generic_levels": "alevel",
         "mip_era": "CMIP6", 
         "Conventions": "CF-1.6 CMIP-6.0"
     }, 

--- a/Tables/CMIP6_CF3hr.json
+++ b/Tables/CMIP6_CF3hr.json
@@ -9,7 +9,7 @@
         "missing_value": "1e20", 
         "product": "output", 
         "approx_interval": "", 
-        "generic_levels": "", 
+        "generic_levels": "alevel alevhalf",
         "mip_era": "CMIP6", 
         "Conventions": "CF-1.6 CMIP-6.0"
     }, 

--- a/Tables/CMIP6_CFday.json
+++ b/Tables/CMIP6_CFday.json
@@ -9,7 +9,7 @@
         "missing_value": "1e20", 
         "product": "output", 
         "approx_interval": "", 
-        "generic_levels": "", 
+        "generic_levels": "alevel alevhalf",
         "mip_era": "CMIP6", 
         "Conventions": "CF-1.6 CMIP-6.0"
     }, 

--- a/Tables/CMIP6_CFmon.json
+++ b/Tables/CMIP6_CFmon.json
@@ -9,7 +9,7 @@
         "missing_value": "1e20", 
         "product": "output", 
         "approx_interval": "", 
-        "generic_levels": "", 
+        "generic_levels": "alevel alevhalf",
         "mip_era": "CMIP6", 
         "Conventions": "CF-1.6 CMIP-6.0"
     }, 

--- a/Tables/CMIP6_CFsubhr.json
+++ b/Tables/CMIP6_CFsubhr.json
@@ -9,7 +9,7 @@
         "missing_value": "1e20", 
         "product": "output", 
         "approx_interval": "", 
-        "generic_levels": "", 
+        "generic_levels": "alevel alevhalf",
         "mip_era": "CMIP6", 
         "Conventions": "CF-1.6 CMIP-6.0"
     }, 

--- a/Tables/CMIP6_E3hr.json
+++ b/Tables/CMIP6_E3hr.json
@@ -9,7 +9,7 @@
         "missing_value": "1e20", 
         "product": "output", 
         "approx_interval": "", 
-        "generic_levels": "", 
+        "generic_levels": "alevel",
         "mip_era": "CMIP6", 
         "Conventions": "CF-1.6 CMIP-6.0"
     }, 

--- a/Tables/CMIP6_E6hrZ.json
+++ b/Tables/CMIP6_E6hrZ.json
@@ -9,7 +9,7 @@
         "missing_value": "1e20", 
         "product": "output", 
         "approx_interval": "", 
-        "generic_levels": "", 
+        "generic_levels": "alevel",
         "mip_era": "CMIP6", 
         "Conventions": "CF-1.6 CMIP-6.0"
     }, 

--- a/Tables/CMIP6_Efx.json
+++ b/Tables/CMIP6_Efx.json
@@ -9,7 +9,7 @@
         "missing_value": "1e20", 
         "product": "output", 
         "approx_interval": "", 
-        "generic_levels": "", 
+        "generic_levels": "alevel",
         "mip_era": "CMIP6", 
         "Conventions": "CF-1.6 CMIP-6.0"
     }, 

--- a/Tables/CMIP6_Emon.json
+++ b/Tables/CMIP6_Emon.json
@@ -9,7 +9,7 @@
         "missing_value": "1e20", 
         "product": "output", 
         "approx_interval": "", 
-        "generic_levels": "", 
+        "generic_levels": "alevel",
         "mip_era": "CMIP6", 
         "Conventions": "CF-1.6 CMIP-6.0"
     }, 

--- a/Tables/CMIP6_Esubhr.json
+++ b/Tables/CMIP6_Esubhr.json
@@ -9,7 +9,7 @@
         "missing_value": "1e20", 
         "product": "output", 
         "approx_interval": "", 
-        "generic_levels": "", 
+        "generic_levels": "alevel",
         "mip_era": "CMIP6", 
         "Conventions": "CF-1.6 CMIP-6.0"
     }, 


### PR DESCRIPTION
We have found that some of the tables are using the generic levels alevel and alevhalf but the tables are not declaring them at the header.

This pull request contains the fix for this.