### PR TITLE
removed hdf5=1.10.2 from .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -q -n py2 -c cdat/label/nightly -c pcmdi/label/nightly -c conda-forge -c cdat cmor python=2.7 hdf5=1.10.2 testsrunner
+       conda create -q -n py2 -c cdat/label/nightly -c pcmdi/label/nightly -c conda-forge -c cdat cmor python=2.7 testsrunner
 
   - &setup_cmor
     name: setup_cmor


### PR DESCRIPTION
Removed getting previous version of hdf5 used by an older version of nightly.