### PR TITLE
Removed 'hdf5=1.10.2' from conda environment creation for Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -q -n py2 -c cdat/label/nightly -c pcmdi/label/nightly -c conda-forge -c cdat cmor python=2.7 hdf5=1.10.2 testsrunner
+       conda create -q -n py2 -c cdat/label/nightly -c pcmdi/label/nightly -c conda-forge -c cdat cmor python=2.7 testsrunner
 
   - &setup_cmor
     name: setup_cmor


### PR DESCRIPTION
hdf5 1.10.2 was used by an older version of CMOR nightly.  Since nightly has been recently updated it is no longer needed.