### PR TITLE
Adding example user input JSON to CMIP6 tables

### DIFF
--- a/Tables/CMIP6_input_example.json
+++ b/Tables/CMIP6_input_example.json
@@ -70,5 +70,5 @@
  
     "#output_path_template":   "Template for output path directory using tables keys or global attributes, these should follow the relevant data reference syntax",
     "output_path_template":    "<mip_era><activity_id><institution_id><source_id><experiment_id><_member_id><table><variable_id><grid_label><version>",
-    "output_file_template":    "<variable_id><table><source_id><experiment_id><_member_id><grid_label>",
+    "output_file_template":    "<variable_id><table><source_id><experiment_id><_member_id><grid_label>"
  }

--- a/Tables/CMIP6_input_example.json
+++ b/Tables/CMIP6_input_example.json
@@ -1,0 +1,74 @@
+{
+    "#note":           "explanation of what source_type is goes here",
+    "source_type":            "AOGCM ISM AER",
+ 
+    "#note":                  "CMIP6 valid experiment_ids are found in CMIP6_CV.json",
+    "experiment_id":          "piControl-withism",
+    "activity_id":            "ISMIP6",
+    "sub_experiment_id":      "none",
+ 
+    "realization_index":      "3",
+    "initialization_index":   "1",
+    "physics_index":          "1",
+    "forcing_index":          "1",
+ 
+    "#note":                  "Text stored in attribute variant_info (recommended, not required description of run variant)",
+    "run_variant":            "3rd realization",
+ 
+    "parent_experiment_id":   "historical",
+    "parent_activity_id":     "CMIP",
+    "parent_source_id":       "PCMDI-test-1-0",
+    "parent_variant_label":   "r3i1p1f1",
+ 
+    "parent_time_units":      "days since 1850-01-01",
+    "branch_method":          "standard",
+    "branch_time_in_child":   59400.0,
+    "branch_time_in_parent":  59400.0,
+ 
+    "#note":                  "institution_id must be registered at https://github.com/WCRP-CMIP/CMIP6_CVs/issues/new ",
+    "institution_id":         "PCMDI",
+ 
+    "#note":                  "source_id (model name) must be registered at https://github.com/WCRP-CMIP/CMIP6_CVs/issues/new ",
+    "source_id":              "PCMDI-test-1-0",
+ 
+    "calendar":               "360_day",
+ 
+    "grid":                   "native atmosphere regular grid (3x4 latxlon)",
+    "grid_label":             "gn",
+    "nominal_resolution":     "10000 km",
+ 
+    "license":                 "CMIP6 model data produced by Lawrence Livermore PCMDI is licensed under a Creative Commons Attribution ShareAlike 4.0 International License (https://creativecommons.org/licenses). Consult https://pcmdi.llnl.gov/CMIP6/TermsOfUse for terms of use governing CMIP6 output, including citation requirements and proper acknowledgment. Further information about this data, including some limitations, can be found via the further_info_url (recorded as a global attribute in this file) and at https:///pcmdi.llnl.gov/. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law.",
+ 
+    "#output":                "Root directory for output (can be either a relative or full path)",
+    "outpath":                "CMIP6",
+ 
+    "#note":                  " **** The following descriptors are optional and may be set to an empty string ",  
+ 
+    "contact ":               "Python Coder (coder@a.b.c.com)",
+    "history":                "Output from archivcl_A1.nce/giccm_03_std_2xCO2_2256.",
+    "comment":                "",
+    "references":             "Model described by Koder and Tolkien (J. Geophys. Res., 2001, 576-591).  Also see http://www.GICC.su/giccm/doc/index.html.  The ssp245 simulation is described in Dorkey et al. '(Clim. Dyn., 2003, 323-357.)'",
+ 
+    "#note":                  " **** The following will be obtained from the CV and do not need to be defined here", 
+ 
+    "sub_experiment":         "none",
+    "institution":            "",
+    "source":                 "PCMDI-test 1.0 (1989)",
+ 
+    "#note":                  " **** The following are set correctly for CMIP6 and should not normally need editing",  
+ 
+    "_control_vocabulary_file": "CMIP6_CV.json",
+    "_AXIS_ENTRY_FILE":         "CMIP6_coordinate.json",
+    "_FORMULA_VAR_FILE":        "CMIP6_formula_terms.json",
+    "_cmip6_option":           "CMIP6",
+ 
+    "mip_era":                "CMIP6",
+    "parent_mip_era":         "CMIP6",
+ 
+    "tracking_prefix":        "hdl:21.14100",
+    "_history_template":       "%s ;rewrote data to be consistent with <activity_id> for variable <variable_id> found in table <table_id>.",
+ 
+    "#output_path_template":   "Template for output path directory using tables keys or global attributes, these should follow the relevant data reference syntax",
+    "output_path_template":    "<mip_era><activity_id><institution_id><source_id><experiment_id><_member_id><table><variable_id><grid_label><version>",
+    "output_file_template":    "<variable_id><table><source_id><experiment_id><_member_id><grid_label>",
+ }

--- a/Tables/CMIP6_input_example.json
+++ b/Tables/CMIP6_input_example.json
@@ -1,8 +1,8 @@
 {
-    "#note":           "explanation of what source_type is goes here",
+    "#note_source_type":      "explanation of what source_type is goes here",
     "source_type":            "AOGCM ISM AER",
  
-    "#note":                  "CMIP6 valid experiment_ids are found in CMIP6_CV.json",
+    "#note_experiment_id":    "CMIP6 valid experiment_ids are found in CMIP6_CV.json",
     "experiment_id":          "piControl-withism",
     "activity_id":            "ISMIP6",
     "sub_experiment_id":      "none",
@@ -12,7 +12,7 @@
     "physics_index":          "1",
     "forcing_index":          "1",
  
-    "#note":                  "Text stored in attribute variant_info (recommended, not required description of run variant)",
+    "#note_run_variant":      "Text stored in attribute variant_info (recommended, not required description of run variant)",
     "run_variant":            "3rd realization",
  
     "parent_experiment_id":   "historical",
@@ -25,10 +25,10 @@
     "branch_time_in_child":   59400.0,
     "branch_time_in_parent":  59400.0,
  
-    "#note":                  "institution_id must be registered at https://github.com/WCRP-CMIP/CMIP6_CVs/issues/new ",
+    "#note_institution_id":   "institution_id must be registered at https://github.com/WCRP-CMIP/CMIP6_CVs/issues/new ",
     "institution_id":         "PCMDI",
  
-    "#note":                  "source_id (model name) must be registered at https://github.com/WCRP-CMIP/CMIP6_CVs/issues/new ",
+    "#note_source_id":        "source_id (model name) must be registered at https://github.com/WCRP-CMIP/CMIP6_CVs/issues/new ",
     "source_id":              "PCMDI-test-1-0",
  
     "calendar":               "360_day",
@@ -42,20 +42,20 @@
     "#output":                "Root directory for output (can be either a relative or full path)",
     "outpath":                "CMIP6",
  
-    "#note":                  " **** The following descriptors are optional and may be set to an empty string ",  
+    "#note_optional":         " **** The following descriptors are optional and may be set to an empty string ",  
  
     "contact ":               "Python Coder (coder@a.b.c.com)",
     "history":                "Output from archivcl_A1.nce/giccm_03_std_2xCO2_2256.",
     "comment":                "",
     "references":             "Model described by Koder and Tolkien (J. Geophys. Res., 2001, 576-591).  Also see http://www.GICC.su/giccm/doc/index.html.  The ssp245 simulation is described in Dorkey et al. '(Clim. Dyn., 2003, 323-357.)'",
  
-    "#note":                  " **** The following will be obtained from the CV and do not need to be defined here", 
+    "#note_CV":               " **** The following will be obtained from the CV and do not need to be defined here", 
  
     "sub_experiment":         "none",
     "institution":            "",
     "source":                 "PCMDI-test 1.0 (1989)",
  
-    "#note":                  " **** The following are set correctly for CMIP6 and should not normally need editing",  
+    "#note_CMIP6":            " **** The following are set correctly for CMIP6 and should not normally need editing",  
  
     "_control_vocabulary_file": "CMIP6_CV.json",
     "_AXIS_ENTRY_FILE":         "CMIP6_coordinate.json",


### PR DESCRIPTION
As suggested by @taylor13 in https://github.com/PCMDI/cmor3_documentation/issues/63, we should move CMOR_input_example.json from CMOR's test directory to the CMIP6 tables directory in this repo.  Once merged, we should also change links to the input example and the cmor_dataset_json() path for tests.