### PR TITLE
Update CircleCI tests to use Python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -q -n py3 -c cdat/label/nightly -c pcmdi/label/nightly -c conda-forge -c cdat lazy-object-proxy libnetcdf=4.6.2 cmor python=3.7 testsrunner
+       conda create -q -n py3 -c cdat/label/nightly -c pcmdi/label/nightly -c conda-forge -c cdat lazy-object-proxy cmor=3.5.0 python=3.7 testsrunner
 
   - &setup_cmor
     name: setup_cmor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -q -n py3 -c cdat/label/nightly -c pcmdi/label/nightly -c conda-forge -c cdat lazy-object-proxy cmor python=3.7 testsrunner
+       conda create -q -n py3 -c cdat/label/nightly -c pcmdi/label/nightly -c conda-forge -c cdat lazy-object-proxy libnetcdf=4.6.2 cmor python=3.7 testsrunner
 
   - &setup_cmor
     name: setup_cmor
@@ -45,6 +45,7 @@ aliases:
        set -e
        cp Tables/* cmor/Tables
        cd cmor
+       export PYTHONPATH=Test
        python run_tests.py -v2 -H -n1 Test/test_python_CMIP6_CV*.py
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ aliases:
       git clone -b validateNightly git@github.com:CDAT/cdat workspace/cdat
       ls workspace/cdat
       # following will install miniconda3 under $WORKDIR/miniconda/bin
-      python workspace/cdat/scripts/install_miniconda.py -w $WORKDIR -p 'py2.7'
+      python workspace/cdat/scripts/install_miniconda.py -w $WORKDIR -p 'py3.7'
       
   - &create_conda_env
     name: create_conda_env
@@ -22,14 +22,14 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -q -n py2 -c cdat/label/nightly -c pcmdi/label/nightly -c conda-forge -c cdat lazy-object-proxy libnetcdf=4.6.2 cmor=3.5.0.2019.11.06 python=2.7 testsrunner
+       conda create -q -n py3 -c cdat/label/nightly -c pcmdi/label/nightly -c conda-forge -c cdat lazy-object-proxy cmor python=3.7 testsrunner
 
   - &setup_cmor
     name: setup_cmor
     command: |
        export PATH=$WORKDIR/miniconda/bin:$PATH
        set +e
-       source activate py2
+       source activate py3
        echo "ACTIVATE RETURN CODE $?"
        set -e
        git clone https://github.com/PCMDI/cmor
@@ -41,7 +41,7 @@ aliases:
        export PATH=$WORKDIR/miniconda/bin:$PATH
        export UVCDAT_ANONYMOUS_LOG=False
        set +e
-       source activate py2
+       source activate py3
        set -e
        cp Tables/* cmor/Tables
        cd cmor


### PR DESCRIPTION
Update the CircleCI tests to use Python 3.7.

Pinning the nightly version of CMOR to 3.5.0 will now get the latest nightly build of CMOR 3.5.0 and the compatible version of libnetcdf.