### PR TITLE
Change "_control_vocabulary_file" to "_controlled_vocabulary_file" in user input example

### DIFF
--- a/Tables/CMIP6_input_example.json
+++ b/Tables/CMIP6_input_example.json
@@ -57,7 +57,7 @@
  
     "#note_CMIP6":            " **** The following are set correctly for CMIP6 and should not normally need editing",  
  
-    "_control_vocabulary_file": "CMIP6_CV.json",
+    "_controlled_vocabulary_file": "CMIP6_CV.json",
     "_AXIS_ENTRY_FILE":         "CMIP6_coordinate.json",
     "_FORMULA_VAR_FILE":        "CMIP6_formula_terms.json",
     "_cmip6_option":           "CMIP6",


### PR DESCRIPTION
Apply changes for https://github.com/PCMDI/cmor3_documentation/issues/55 and https://github.com/PCMDI/cmor/issues/488