### PR TITLE
cron: update CMIP6_CV -- 2021-07-26T18:18

### DIFF
--- a/Tables/CMIP6_CV.json
+++ b/Tables/CMIP6_CV.json
@@ -33,13 +33,13 @@
             "variant_label"
         ],
         "version_metadata":{
-            "CV_collection_modified":"Thu Jul 22 11:35:33 2021 -0700",
-            "CV_collection_version":"6.2.56.3",
+            "CV_collection_modified":"Mon Jul 26 10:57:20 2021 -0700",
+            "CV_collection_version":"6.2.56.4",
             "author":"Paul J. Durack <durack1@llnl.gov>",
             "experiment_id_CV_modified":"Tue Dec 15 12:25:59 2020 -0800",
             "experiment_id_CV_note":"Revise experiment_id historical parent experiments",
             "institution_id":"PCMDI",
-            "previous_commit":"66344226746627e0b6c12db974666126c343ce27",
+            "previous_commit":"5afeb3ffd3b98e23b9c2ff76015fc7c87a5dbd71",
             "specs_doc":"v6.2.7 (10th September 2018; https://goo.gl/v1drZl)"
         },
         "activity_id":{


### PR DESCRIPTION
@durack1 The changes from https://github.com/WCRP-CMIP/CMIP6_CVs/pull/1035/commits/68075bb4d76d21d23e3ee4f39230c72323970664 have only changed the `CV_collection_version` value in CMIP6_CV.json.  Was there any other change that should have appeared in this file?